### PR TITLE
show error message when failed to parse mavlink message warning

### DIFF
--- a/libs/mavio/src/MAVLinkTCP.cc
+++ b/libs/mavio/src/MAVLinkTCP.cc
@@ -188,7 +188,8 @@ bool MAVLinkTCP::receive_message(mavlink_message_t& msg) {
                "TCP >> FAILED (The stream socket peer has performed an "
                "orderly shutdown)");
   } else {
-    mavio::log(LOG_WARNING, "Failed to parse MAVLink message.");
+    mavio::log(LOG_WARNING, "Failed to parse MAVLink message. %s",
+               strerror(errno)););
   }
 
   return false;


### PR DESCRIPTION
I am doing a fork of this project in which I need the TCP part to be server, not client. I realized logging this error might be useful, because if not, we have no feedback of the error if recv returns < 1.